### PR TITLE
Update obsidian.css

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -475,6 +475,7 @@ thead {
 /* search result in backlink or file search */
 .search-result-file-title {  
   font-size: var(--font-size-side-dock-title) ;
+  margin-left: 5px;
 }
 
 .search-result-file-matches, .search-empty-state {
@@ -485,6 +486,11 @@ thead {
 .search-result-file-title,
 .search-result-file-match {
   padding: 0px 10px;
+}
+
+/*remove padding from collapse indicator*/
+.search-result-collapse-indicator {
+    padding: 0px;
 }
 
 .nav-file-title, .nav-folder-title {


### PR DESCRIPTION
Fixes an issue where the collapse indicator overlaps the title span for list items and adds a small margin to inset list items.

![image](https://user-images.githubusercontent.com/16765522/94331040-1a028380-ff8f-11ea-812d-70b8152b29a4.png)


> If you're fixing a UI issue, make sure you take two screenshots. One that shows the actual bug and another that shows how you fixed it.