### PR TITLE
fix: Create space between blockquotes

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -394,7 +394,7 @@ pre code {
   border-left-width: 4px !important;
   border-radius: 0 8px 8px 0;
   line-height: 1.5em;
-  margin: 0 10px;
+  margin: 30px 0px;
   font-style: italic;
 }
 


### PR DESCRIPTION
> If you're fixing a UI issue, make sure you take two screenshots. One that shows the actual bug and another that shows how you fixed it.

Hi!

I encountered a 'bug' on the blockquotes and I'm trying to address it here.

The blockquotes were being merged into a single blockquote: 
![image](https://user-images.githubusercontent.com/44419136/98465358-64d70400-21a7-11eb-853e-2d11144545b5.png)

Actual md:
![image](https://user-images.githubusercontent.com/44419136/98465374-702a2f80-21a7-11eb-8b73-b94bbdd253e1.png)

It didn't matter adding a tail `>` either:
![image](https://user-images.githubusercontent.com/44419136/98465382-7ddfb500-21a7-11eb-8881-9a58efaa0330.png)

So the fix I'm suggesting will have the following result:
![image](https://user-images.githubusercontent.com/44419136/98465394-9059ee80-21a7-11eb-9cdf-3383c1c78c69.png)

 I hope you find this useful!

Thanks for looking into it.