### PR TITLE
Modify scrollbar styles

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -46,9 +46,9 @@
   --interactive-accent: #ffb86c;
   --interactive-accent-rgb: 123, 108, 217;
   --interactive-accent-hover: #ff5555;
-  --scrollbar-active-thumb-bg: #282a36;
-  --scrollbar-bg: #282a36;
-  --scrollbar-thumb-bg: #282a36;
+  --scrollbar-active-thumb-bg: rgba(255, 255, 255, 0.2);
+  --scrollbar-bg: rgba(255, 255, 255, 0.05);
+  --scrollbar-thumb-bg: rgba(255, 255, 255, 0.1);
 
   --text-title-h1:              #ff79c6;
   --text-title-h2:              #bd93f9;


### PR DESCRIPTION
Hi, I'm dracula theme lover, and appreciative your code.
So, I would love to make a contribution .

I think scrollbar's style doesn't work well, please see the following screenshots.

<img width="1009" alt="before" src="https://user-images.githubusercontent.com/35160194/104819701-8b35b180-5872-11eb-9cc8-19e1cfa6d244.png">

The scrollbar in left tab is filled with primary color and i cant recognize it as a scrollbar for the first time.
So I changed these variables.

```
  --scrollbar-active-thumb-bg
  --scrollbar-bg
  --scrollbar-thumb-bg
```

normal | hover
---- | ----
<img width="1009" alt="scrollbar" src="https://user-images.githubusercontent.com/35160194/104819824-802f5100-5873-11eb-802b-83bc485be28f.png"> | <img width="1009" alt="scrollbar-active" src="https://user-images.githubusercontent.com/35160194/104819820-7b6a9d00-5873-11eb-8425-ac171af6242e.png">

This modification is also affect to main tab.
<img width="505" alt="スクリーンショット 2021-01-17 3 13 12" src="https://user-images.githubusercontent.com/35160194/104819894-37c46300-5874-11eb-8697-e46613aec0eb.png">

These colors are base on default value. If you don't set explicitly it will work well.