### PR TITLE
Exclude emojis from embedded image rules

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -260,7 +260,7 @@ s, .cm-strikethrough {
 }
 
 /* embedded images */
-img {
+img:not(.emoji) {
   display: block;
   margin-left: auto;
   margin-right: auto;


### PR DESCRIPTION
Hi Jarodise,

I have created an emoji plugin that is clashing with some themes that center images as I also use the `<img>` tag to customise the appearance of emojis. Do you mind considering this fix providing you require images to always be centered as part of your theme.

With Bug

![image](https://user-images.githubusercontent.com/17361662/112177545-f09a7b80-8bf0-11eb-9613-aad8d67b14f0.png)

Without Bug

![image](https://user-images.githubusercontent.com/17361662/112177930-42430600-8bf1-11eb-9d28-e15edcc008aa.png)

